### PR TITLE
コメントしたユーザー詳細に飛ぶ実装

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -45,7 +45,7 @@
           <% @comments.each do |comment| %>
             <li class="comments_list">
               <%= comment.content %>
-              <%= link_to " #{comment.user.name} ", root_path, class: :comment_user %>
+              <%= link_to " #{comment.user.name} ", user_path(comment.user_id), class: :comment_user %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
#What
root_path の記述を、コメントした人の詳細ページに飛ぶように変えた


#Why
プロトタイプにコメントしたユーザーの詳細を押すと、その人の詳細ページに飛べるようにしたい